### PR TITLE
fixing issue regarding headers being lost along the way.

### DIFF
--- a/persistence/src/main/java/tech/nermindedovic/persistence/business/service/ConsumerService.java
+++ b/persistence/src/main/java/tech/nermindedovic/persistence/business/service/ConsumerService.java
@@ -31,7 +31,6 @@ public class ConsumerService {
     @KafkaListener(topics = PersistenceTopicNames.INBOUND_BALANCE_REQUEST, groupId = "persistence")
     @SendTo({"balance.update.response"})
     public String handleBalanceRequest(@NotNull final String xml) {
-        log.info("PERSISTENCE RECIEVED: " + xml);
         return processor.processBalanceRequest(xml);
     }
 

--- a/router-streams/src/main/java/tech/nermindedovic/routerstreams/config/BalanceProcessor.java
+++ b/router-streams/src/main/java/tech/nermindedovic/routerstreams/config/BalanceProcessor.java
@@ -5,6 +5,7 @@ import org.jdom2.JDOMException;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
 import tech.nermindedovic.routerstreams.exception.InvalidRoutingNumberException;
 import tech.nermindedovic.routerstreams.utils.BalanceMessageParser;
 import tech.nermindedovic.routerstreams.utils.RouterAppUtils;
@@ -25,13 +26,13 @@ public class BalanceProcessor {
 
 
     @Bean
-    public Consumer<String> balanceRequestConsumer() {
-        return xml -> {
+    public Consumer<Message<String>> balanceRequestConsumer() {
+        return record -> {
             try {
-                log.info("ROUTER RECIEVED:" + xml);
-                BalanceMessageParser parser = new BalanceMessageParser(xml);
-                streamBridge.send(RouterTopicNames.OUTBOUND_BALANCE_REQUEST_PREFIX + parser.getRoute(), xml);
-                log.info("ROUTER SENDING :" + xml);
+                log.info("ROUTER RECIEVED:" + record);
+                BalanceMessageParser parser = new BalanceMessageParser(record.getPayload());
+                streamBridge.send(RouterTopicNames.OUTBOUND_BALANCE_REQUEST_PREFIX + parser.getRoute(), record);
+                log.info("ROUTER SENDING :" + record);
             } catch (JDOMException | IOException | InvalidRoutingNumberException e) {
                 log.error(e.getMessage());
                 streamBridge.send(RouterTopicNames.OUTBOUND_BALANCE_RETURN_TOPIC, RouterAppUtils.BALANCE_ERROR_XML);

--- a/router-streams/src/main/resources/application.yaml
+++ b/router-streams/src/main/resources/application.yaml
@@ -29,9 +29,11 @@ spring:
 
 
 
+
+
       kafka:
         binder:
-          headers: correlationId, RecordHeader
+          headers: correlationId
         streams:
           binder:
             configuration:
@@ -41,7 +43,7 @@ spring:
               commit.interval.ms: 1000
             auto-create-topics: true
             brokers: localhost:9092
-            headers: correlationId, RecordHeader
+
 
 
         bindings:
@@ -50,6 +52,8 @@ spring:
           consumeInitialTransfer-in-0:
             enableDlq: true
             dlqName: funds.transfer.error
+
+
 
 
 


### PR DESCRIPTION
StreamBridge will not transfer over headers from a consumed message. Changed router-streams consumer input for balance request -- from `String` to `Message<String>`, in order to pipe the message down with all of its present headers still intact